### PR TITLE
ci: fix Android metadata validation workflow

### DIFF
--- a/.github/workflows/validate-metadata.yml
+++ b/.github/workflows/validate-metadata.yml
@@ -12,6 +12,6 @@ jobs:
      - uses: actions/checkout@v3
      - uses: ashutoshgngwr/validate-fastlane-supply-metadata@v2
        with:
-        fastlaneDir: ./fastlane # optional. default is './fastlane'.
+        fastlaneDir: ./fastlane/android/metadata # optional. default is './fastlane/metadata/android'.
         # enable check to validate if a locale is supported by the Play Store Listing.
         usePlayStoreLocales: true # optional. default is false.


### PR DESCRIPTION
_validate-fastlane-supply-metadata@v2_ expects the full path to the Android metadata directory (where locale directories are located).